### PR TITLE
Portability: use temporary files instead of "sed -i".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ distribution: documentation source_tarball package
 
 %.app: %.app.in $(SOURCES) $(BROKER_DIR)/generate_app
 	escript  $(BROKER_DIR)/generate_app $< $@ $(SOURCE_DIR)
-	sed -i.save 's/%%VSN%%/$(VERSION)/' $@ && rm $@.save
+	sed 's/%%VSN%%/$(VERSION)/' $@ > $@.tmp && mv $@.tmp $@
 
 ###############################################################################
 ##  Dialyzer


### PR DESCRIPTION
The "-i" option isn't available on BSD systems.

NOTE: You've got my CLA on file.
