### PR TITLE
amqp_client.app.in: add missing dependency to rabbit_common

### DIFF
--- a/ebin/amqp_client.app.in
+++ b/ebin/amqp_client.app.in
@@ -6,4 +6,4 @@
   {env, [{prefer_ipv6, false},
          {ssl_options, []}]},
   {mod, {amqp_client, []}},
-  {applications, [kernel, stdlib, xmerl]}]}.
+  {applications, [kernel, stdlib, xmerl, rabbit_common]}]}.


### PR DESCRIPTION
The rabbit_common lib is not included when building a Erlang release unless rabbit_common is listed somewhere. And as it is a dependency of amqp_client, this is the right place to put it.
