### PR TITLE
Include `ssl_compat` in rabbit_common

### DIFF
--- a/rabbit_common.app.in
+++ b/rabbit_common.app.in
@@ -37,6 +37,7 @@
              rabbit_queue_collector,
              rabbit_queue_decorator,
              rabbit_amqqueue,
+             ssl_compat,
              supervisor2
   ]},
   {registered, []},


### PR DESCRIPTION
This **must** be merged with rabbitmq/rabbitmq-server#247.

References rabbitmq/rabbitmq-server#246.