### PR TITLE
Support the new Time API in Erlang 18.0

### DIFF
--- a/rabbit_common.app.in
+++ b/rabbit_common.app.in
@@ -38,7 +38,8 @@
              rabbit_queue_decorator,
              rabbit_amqqueue,
              ssl_compat,
-             supervisor2
+             supervisor2,
+             time_compat
   ]},
   {registered, []},
   {env, []},

--- a/src/amqp_direct_connection.erl
+++ b/src/amqp_direct_connection.erl
@@ -130,7 +130,8 @@ connect(Params = #amqp_params_direct{username     = Username,
                          vhost        = VHost,
                          params       = Params,
                          adapter_info = ensure_adapter_info(Info),
-                         connected_at = rabbit_misc:now_to_ms(os:timestamp())},
+                         connected_at =
+                           time_compat:os_system_time(milli_seconds)},
     case rpc:call(Node, rabbit_direct, connect,
                   [{Username, Password}, VHost, ?PROTOCOL, self(),
                    connection_info(State1)]) of

--- a/test/test_util.erl
+++ b/test/test_util.erl
@@ -863,7 +863,9 @@ large_content_test() ->
     {ok, Channel} = amqp_connection:open_channel(Connection),
     #'queue.declare_ok'{queue = Q}
         = amqp_channel:call(Channel, #'queue.declare'{}),
-    {A1,A2,A3} = now(), random:seed(A1, A2, A3),
+    random:seed(erlang:phash2([node()]),
+                time_compat:monotonic_time(),
+                time_compat:unique_integer()),
     F = list_to_binary([random:uniform(256)-1 || _ <- lists:seq(1, 1000)]),
     Payload = list_to_binary([[F || _ <- lists:seq(1, 1000)]]),
     Publish = #'basic.publish'{exchange = <<>>, routing_key = Q},


### PR DESCRIPTION
It must be merged **at the same time as** rabbitmq/rabbitmq-server#254.

References rabbitmq/rabbitmq-server#233.