### PR TITLE
Fix preprocessor ifdef for specs

### DIFF
--- a/include/amqp_gen_consumer_spec.hrl
+++ b/include/amqp_gen_consumer_spec.hrl
@@ -16,7 +16,7 @@
 
 -include("amqp_client.hrl").
 
--ifndef(edoc).
+-ifdef(use_specs).
 -type(state() :: any()).
 -type(consume() :: #'basic.consume'{}).
 -type(consume_ok() :: #'basic.consume_ok'{}).


### PR DESCRIPTION
The OTP 19 master branch gives syntax errors for the specs format used in RabbitMQ:

    amqp_gen_consumer_spec.hrl:30: syntax error before: '/'

This patch replaces the "edoc" ifdef with "use_specs" (like in all other places), so RabbitMQ can be compiled with the OTP 19 master branch.