### PR TITLE
Fix regression from adding ssl_compat module

### DIFF
--- a/src/amqp_direct_connection.erl
+++ b/src/amqp_direct_connection.erl
@@ -193,9 +193,10 @@ maybe_ssl_info(Sock) ->
 ssl_info(Sock) ->
     {Protocol, KeyExchange, Cipher, Hash} =
         case rabbit_net:ssl_info(Sock) of
-            {ok, {P, {K, C, H}}}    -> {P, K, C, H};
-            {ok, {P, {K, C, H, _}}} -> {P, K, C, H};
-            _                       -> {unknown, unknown, unknown, unknown}
+            {ok, Infos} -> {_, P}         = lists:keyfind(protocol, 1, Infos),
+                           {_, {K, C, H}} = lists:keyfind(cipher_suite, 1, Infos),
+                           {P, K, C, H};
+            A           -> {unknown, unknown, unknown, unknown}
         end,
     [{ssl_protocol,     Protocol},
      {ssl_key_exchange, KeyExchange},

--- a/src/amqp_direct_connection.erl
+++ b/src/amqp_direct_connection.erl
@@ -196,7 +196,7 @@ ssl_info(Sock) ->
             {ok, Infos} -> {_, P}         = lists:keyfind(protocol, 1, Infos),
                            {_, {K, C, H}} = lists:keyfind(cipher_suite, 1, Infos),
                            {P, K, C, H};
-            A           -> {unknown, unknown, unknown, unknown}
+            _           -> {unknown, unknown, unknown, unknown}
         end,
     [{ssl_protocol,     Protocol},
      {ssl_key_exchange, KeyExchange},


### PR DESCRIPTION
This makes management properly display SSL details for STOMP
connections.

Part of https://github.com/rabbitmq/rabbitmq-stomp/issues/55