### PR TITLE
Match ssl_info ciphersuite format in Erlang/OTP 18.3

### DIFF
--- a/src/amqp_direct_connection.erl
+++ b/src/amqp_direct_connection.erl
@@ -193,10 +193,14 @@ maybe_ssl_info(Sock) ->
 ssl_info(Sock) ->
     {Protocol, KeyExchange, Cipher, Hash} =
         case rabbit_net:ssl_info(Sock) of
-            {ok, Infos} -> {_, P}         = lists:keyfind(protocol, 1, Infos),
-                           {_, {K, C, H}} = lists:keyfind(cipher_suite, 1, Infos),
-                           {P, K, C, H};
-            _           -> {unknown, unknown, unknown, unknown}
+            {ok, Infos} ->
+                {_, P} = lists:keyfind(protocol, 1, Infos),
+                case lists:keyfind(cipher_suite, 1, Infos) of
+                    {_,{K, C, H}}    -> {P, K, C, H};
+                    {_,{K, C, H, _}} -> {P, K, C, H}
+                end;
+            _           ->
+                {unknown, unknown, unknown, unknown}
         end,
     [{ssl_protocol,     Protocol},
      {ssl_key_exchange, KeyExchange},


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-mqtt/issues/75

Cipher suites in OTP18 are reported as 4-element tuples when using TLS1.2