### PR TITLE
Connection returns user internal info.

### DIFF
--- a/src/amqp_direct_connection.erl
+++ b/src/amqp_direct_connection.erl
@@ -108,6 +108,7 @@ i(port,         #state{adapter_info = I}) -> I#amqp_adapter_info.port;
 i(peer_host,    #state{adapter_info = I}) -> I#amqp_adapter_info.peer_host;
 i(peer_port,    #state{adapter_info = I}) -> I#amqp_adapter_info.peer_port;
 i(name,         #state{adapter_info = I}) -> I#amqp_adapter_info.name;
+i(internal_user, #state{user = U}) -> U;
 
 i(Item, _State) -> throw({bad_argument, Item}).
 


### PR DESCRIPTION
It will allows the client connection to return internal user information that is delivered by direct connection.
Related to issue #52 and PR rabbitmq/rabbitmq-mqtt#80