### PR TITLE
Use bound OTP workers timeouts

### DIFF
--- a/src/amqp_channel_sup.erl
+++ b/src/amqp_channel_sup.erl
@@ -37,7 +37,7 @@ start_link(Type, Connection, ConnName, InfraArgs, ChNumber,
                     Sup, {channel,
                           {amqp_channel, start_link,
                            [Type, Connection, ChNumber, ConsumerPid, Identity]},
-                          intrinsic, ?MAX_WAIT, worker, [amqp_channel]}),
+                          intrinsic, ?WORKER_WAIT, worker, [amqp_channel]}),
     Writer = start_writer(Sup, Type, InfraArgs, ConnName, ChNumber, ChPid),
     amqp_channel:set_writer(ChPid, Writer),
     {ok, AState} = init_command_assembler(Type),
@@ -60,7 +60,7 @@ start_writer(Sup, network, [Sock, FrameMax], ConnName, ChNumber, ChPid) ->
                      {writer, {rabbit_writer, start_link,
                                [Sock, ChNumber, FrameMax, ?PROTOCOL, ChPid,
                                 {ConnName, ChNumber}]},
-                      transient, ?MAX_WAIT, worker, [rabbit_writer]}),
+                      transient, ?WORKER_WAIT, worker, [rabbit_writer]}),
     Writer.
 
 init_command_assembler(direct)  -> {ok, none};
@@ -74,4 +74,4 @@ init([{ConsumerModule, ConsumerArgs}, Identity]) ->
     {ok, {{one_for_all, 0, 1},
           [{gen_consumer, {amqp_gen_consumer, start_link,
                            [ConsumerModule, ConsumerArgs, Identity]},
-           intrinsic, ?MAX_WAIT, worker, [amqp_gen_consumer]}]}}.
+           intrinsic, ?WORKER_WAIT, worker, [amqp_gen_consumer]}]}}.

--- a/src/amqp_connection_type_sup.erl
+++ b/src/amqp_connection_type_sup.erl
@@ -48,7 +48,7 @@ start_channels_manager(Sup, Conn, ConnName, Type) ->
                 Sup,
                 {channels_manager, {amqp_channels_manager, start_link,
                                     [Conn, ConnName, ChSupSup]},
-                 transient, ?MAX_WAIT, worker, [amqp_channels_manager]}).
+                 transient, ?WORKER_WAIT, worker, [amqp_channels_manager]}).
 
 start_infrastructure_fun(Sup, Conn, network) ->
     fun (Sock, ConnName) ->
@@ -60,13 +60,13 @@ start_infrastructure_fun(Sup, Conn, network) ->
                   {writer,
                    {rabbit_writer, start_link,
                     [Sock, 0, ?FRAME_MIN_SIZE, ?PROTOCOL, Conn, ConnName]},
-                   transient, ?MAX_WAIT, worker, [rabbit_writer]}),
+                   transient, ?WORKER_WAIT, worker, [rabbit_writer]}),
             {ok, _Reader} =
                 supervisor2:start_child(
                   Sup,
                   {main_reader, {amqp_main_reader, start_link,
                                  [Sock, Conn, ChMgr, AState, ConnName]},
-                   transient, ?MAX_WAIT, worker, [amqp_main_reader]}),
+                   transient, ?WORKER_WAIT, worker, [amqp_main_reader]}),
             {ok, ChMgr, Writer}
     end;
 start_infrastructure_fun(Sup, Conn, direct) ->
@@ -76,7 +76,7 @@ start_infrastructure_fun(Sup, Conn, direct) ->
                 supervisor2:start_child(
                   Sup,
                   {collector, {rabbit_queue_collector, start_link, [ConnName]},
-                   transient, ?MAX_WAIT, worker, [rabbit_queue_collector]}),
+                   transient, ?WORKER_WAIT, worker, [rabbit_queue_collector]}),
             {ok, ChMgr, Collector}
     end.
 


### PR DESCRIPTION
Part of rabbitmq/rabbitmq-server#541
Replace `MAX_WAIT` with `WORKER_WAIT` 