### PR TITLE
Properly handle trapped exits in amqp_gen_connection

### DIFF
--- a/src/amqp_gen_connection.erl
+++ b/src/amqp_gen_connection.erl
@@ -224,6 +224,14 @@ handle_info({'DOWN', _, process, BlockHandler, Reason},
     ?LOG_WARN("Connection (~p): Unregistering block handler ~p because it died. "
               "Reason: ~p~n", [self(), BlockHandler, Reason]),
     {noreply, State#state{block_handler = none}};
+handle_info({'EXIT', BlockHandler, Reason},
+            State = #state{block_handler = {BlockHandler, Ref}}) ->
+    ?LOG_WARN("Connection (~p): Unregistering block handler ~p because it died. "
+              "Reason: ~p~n", [self(), BlockHandler, Reason]),
+    erlang:demonitor(Ref, [flush]),
+    {noreply, State#state{block_handler = none}};
+handle_info({'EXIT', _Pid, _Reason}, State) ->
+    {noreply, State};
 handle_info(Info, State) ->
     callback(handle_message, [Info], State).
 


### PR DESCRIPTION
- Trapped exits were being forwarded to the connection module when it
  has no knowledge of what to do with them
- These unhandled exit messages were causing errors to occur
  unnecessarily
- This changeset ensures trapped exits are handled by the trapping
  process