### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -20,11 +20,9 @@ function main
     kiex_cleanup
 
     ensure_directories
-
     ensure_kerl
-
+    ensure_kiex
     ensure_make
-
     ensure_otp
 }
 

--- a/.travis.sh
+++ b/.travis.sh
@@ -3,28 +3,104 @@
 set -o nounset
 set -o errexit
 
+declare -r tmp_file="$(mktemp)"
 declare -r script_arg="${1:-unset}"
-
-# GNU Make build variables
-declare -r make_install_dir="$HOME/gmake"
-declare -r make_bin_dir="$make_install_dir/bin"
-
-# OTP build variables
-declare -r build_status="$(mktemp)"
-declare -r otp_tag_name="$script_arg"
-declare -r otp_build_log_dir="$HOME/.kerl/builds/$otp_tag_name"
-declare -r otp_install_dir="$HOME/otp/$otp_tag_name"
 
 function onexit
 {
-    rm -vf "$build_status"
+    rm -vf "$tmp_file"
 }
 
 trap onexit EXIT
 
+function main
+{
+    # Note: if script_arg is kiex_cleanup,
+    # this function exits early
+    kiex_cleanup
+
+    ensure_directories
+
+    ensure_kerl
+
+    ensure_make
+
+    ensure_otp
+}
+
+function kiex_cleanup
+{
+    rm -vf $HOME/.kiex/bin/*.bak*
+    rm -vf $HOME/.kiex/elixirs/.*.old
+    rm -vf $HOME/.kiex/elixirs/*.old
+    rm -vf $HOME/.kiex/scripts/*.bak*
+
+    if [[ $script_arg == 'kiex_cleanup' ]]
+    then
+        # Only doing cleanup, so early exit
+        exit 0
+    fi
+}
+
+
+function ensure_directories
+{
+    set +o errexit
+    mkdir "$HOME/otp"
+    mkdir "$HOME/bin"
+    set -o errexit
+    export PATH="$HOME/bin:$PATH"
+}
+
+function ensure_kerl
+{
+    curl -Lo "$HOME/bin/kerl"  https://raw.githubusercontent.com/kerl/kerl/master/kerl
+    chmod 755 "$HOME/bin/kerl"
+}
+
+function ensure_kiex
+{
+    curl -sSL https://raw.githubusercontent.com/taylor/kiex/master/install | /usr/bin/env bash -s
+    local -r kiex_script="$HOME/.kiex/scripts/kiex"
+    if [[ -s $kiex_script ]]
+    then
+        source "$kiex_script"
+        # Note: this produces a lot of output but without running
+        # "list known" first, kiex install ... sometimes fails
+        kiex list known
+        kiex_cleanup
+    else
+        echo "Did not find kiex at $kiex_script" 1>&2
+        exit 1
+    fi
+}
+
+function ensure_make
+{
+    # GNU Make build variables
+    local -r make_install_dir="$HOME/gmake"
+    local -r make_bin_dir="$make_install_dir/bin"
+
+    export PATH="$make_bin_dir:$PATH"
+
+    if [[ -x $make_bin_dir/make ]]
+    then
+        echo "Found GNU Make installation at $make_install_dir"
+    else
+        mkdir -p "$make_install_dir"
+        curl -sLO http://ftp.gnu.org/gnu/make/make-4.2.1.tar.gz
+        tar xf make-4.2.1.tar.gz
+        pushd make-4.2.1
+        ./configure --prefix="$make_install_dir"
+        make
+        make install
+        popd
+    fi
+}
+
 function build_ticker
 {
-    local status="$(< $build_status)"
+    local status="$(< $tmp_file)"
     while [[ $status == 'true' ]]
     do
         echo '------------------------------------------------------------------------------------------------------------------------------------------------'
@@ -34,77 +110,33 @@ function build_ticker
             tail $otp_build_log_dir/otp_build*.log
         fi
         sleep 10
-        status="$(< $build_status)"
+        status="$(< $tmp_file)"
     done
     echo '.'
 }
 
-function kiex_cleanup
+function ensure_otp
 {
-    rm -vf $HOME/.kiex/bin/*.bak*
-    rm -vf $HOME/.kiex/elixirs/.*.old
-    rm -vf $HOME/.kiex/elixirs/*.old
-    rm -vf $HOME/.kiex/scripts/*.bak*
+    # OTP build variables
+    local -r otp_tag_name="$script_arg"
+    local -r otp_build_log_dir="$HOME/.kerl/builds/$otp_tag_name"
+    local -r otp_install_dir="$HOME/otp/$otp_tag_name"
+    if [[ -s $otp_install_dir/activate ]]
+    then
+        echo "Found OTP installation at $otp_install_dir"
+    else
+        export KERL_CONFIGURE_OPTIONS='--enable-hipe --enable-smp-support --enable-threads --enable-kernel-poll'
+        rm -rf "$otp_install_dir"
+        mkdir -p "$otp_install_dir"
+
+        echo -n 'true' > "$tmp_file"
+        build_ticker &
+        kerl build git https://github.com/erlang/otp.git "$otp_tag_name" "$otp_tag_name"
+        echo -n 'false' > "$tmp_file"
+        wait
+
+        kerl install "$otp_tag_name" "$otp_install_dir"
+    fi
 }
 
-if [[ $script_arg == 'kiex_cleanup' ]]
-then
-    kiex_cleanup
-    exit 0
-fi
-
-set +o errexit
-mkdir "$HOME/otp"
-mkdir "$HOME/bin"
-set -o errexit
-
-curl -Lo "$HOME/bin/kerl"  https://raw.githubusercontent.com/kerl/kerl/master/kerl
-chmod 755 "$HOME/bin/kerl"
-export PATH="$HOME/bin:$PATH"
-
-curl -sSL https://raw.githubusercontent.com/taylor/kiex/master/install | /usr/bin/env bash -s
-declare -r kiex_script="$HOME/.kiex/scripts/kiex"
-if [[ -s $kiex_script ]]
-then
-    source "$kiex_script"
-    kiex list known
-    kiex_cleanup
-else
-    echo "Did not find kiex at $kiex_script" 1>&2
-    exit 1
-fi
-
-if [[ -s $make_bin_dir/make ]]
-then
-    echo "Found GNU Make installation at $make_install_dir"
-    export PATH="$make_bin_dir:$PATH"
-else
-    mkdir -p "$make_install_dir"
-    curl -sLO http://ftp.gnu.org/gnu/make/make-4.2.1.tar.gz
-    tar xf make-4.2.1.tar.gz
-    pushd make-4.2.1
-    ./configure --prefix="$make_install_dir"
-    make
-    make install
-    export PATH="$make_bin_dir:$PATH"
-    popd
-fi
-
-if [[ -s $otp_install_dir/activate ]]
-then
-    echo "Found OTP installation at $otp_install_dir"
-else
-    export KERL_CONFIGURE_OPTIONS='--enable-hipe --enable-smp-support --enable-threads --enable-kernel-poll'
-    rm -rf "$otp_install_dir"
-    mkdir -p "$otp_install_dir"
-
-    echo -n 'true' > "$build_status"
-    build_ticker &
-    kerl build git https://github.com/erlang/otp.git "$otp_tag_name" "$otp_tag_name"
-    echo -n 'false' > "$build_status"
-    wait
-
-    kerl install "$otp_tag_name" "$otp_install_dir"
-fi
-
-exit 0
+main

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+
+declare -r script_arg="${1:-unset}"
+
+# GNU Make build variables
+declare -r make_install_dir="$HOME/gmake"
+declare -r make_bin_dir="$make_install_dir/bin"
+
+# OTP build variables
+declare -r build_status="$(mktemp)"
+declare -r otp_tag_name="$script_arg"
+declare -r otp_build_log_dir="$HOME/.kerl/builds/$otp_tag_name"
+declare -r otp_install_dir="$HOME/otp/$otp_tag_name"
+
+function onexit
+{
+    rm -vf "$build_status"
+}
+
+trap onexit EXIT
+
+function build_ticker
+{
+    local status="$(< $build_status)"
+    while [[ $status == 'true' ]]
+    do
+        echo '------------------------------------------------------------------------------------------------------------------------------------------------'
+        echo "$(date) building $otp_tag_name ..."
+        if ls $otp_build_log_dir/otp_build*.log > /dev/null
+        then
+            tail $otp_build_log_dir/otp_build*.log
+        fi
+        sleep 10
+        status="$(< $build_status)"
+    done
+    echo '.'
+}
+
+function kiex_cleanup
+{
+    rm -vf $HOME/.kiex/bin/*.bak*
+    rm -vf $HOME/.kiex/elixirs/.*.old
+    rm -vf $HOME/.kiex/elixirs/*.old
+    rm -vf $HOME/.kiex/scripts/*.bak*
+}
+
+if [[ $script_arg == 'kiex_cleanup' ]]
+then
+    kiex_cleanup
+    exit 0
+fi
+
+set +o errexit
+mkdir "$HOME/otp"
+mkdir "$HOME/bin"
+set -o errexit
+
+curl -Lo "$HOME/bin/kerl"  https://raw.githubusercontent.com/kerl/kerl/master/kerl
+chmod 755 "$HOME/bin/kerl"
+export PATH="$HOME/bin:$PATH"
+
+curl -sSL https://raw.githubusercontent.com/taylor/kiex/master/install | /usr/bin/env bash -s
+declare -r kiex_script="$HOME/.kiex/scripts/kiex"
+if [[ -s $kiex_script ]]
+then
+    source "$kiex_script"
+    kiex list known
+    kiex_cleanup
+else
+    echo "Did not find kiex at $kiex_script" 1>&2
+    exit 1
+fi
+
+if [[ -s $make_bin_dir/make ]]
+then
+    echo "Found GNU Make installation at $make_install_dir"
+    export PATH="$make_bin_dir:$PATH"
+else
+    mkdir -p "$make_install_dir"
+    curl -sLO http://ftp.gnu.org/gnu/make/make-4.2.1.tar.gz
+    tar xf make-4.2.1.tar.gz
+    pushd make-4.2.1
+    ./configure --prefix="$make_install_dir"
+    make
+    make install
+    export PATH="$make_bin_dir:$PATH"
+    popd
+fi
+
+if [[ -s $otp_install_dir/activate ]]
+then
+    echo "Found OTP installation at $otp_install_dir"
+else
+    export KERL_CONFIGURE_OPTIONS='--enable-hipe --enable-smp-support --enable-threads --enable-kernel-poll'
+    rm -rf "$otp_install_dir"
+    mkdir -p "$otp_install_dir"
+
+    echo -n 'true' > "$build_status"
+    build_ticker &
+    kerl build git https://github.com/erlang/otp.git "$otp_tag_name" "$otp_tag_name"
+    echo -n 'false' > "$build_status"
+    wait
+
+    kerl install "$otp_tag_name" "$otp_install_dir"
+fi
+
+exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
 # vim:sw=2:et:
 sudo: false
 
-language: erlang
+language: generic
 
-notifications:
-  email:
-    - alerts@rabbitmq.com
+addons:
+  apt:
+    packages:
+      - unixodbc
+      - unixodbc-dev
+      - libwxgtk2.8-dev
 
-otp_release:
-  - "18.3"
-  - "19.3"
+env:
+  - OTP_TAG_NAME=OTP-20.0
+  - OTP_TAG_NAME=OTP-19.3.6
+  - OTP_TAG_NAME=OTP-18.3.4.5
 
 before_script:
   # The checkout made by Travis is a "detached HEAD" and branches
@@ -23,12 +27,25 @@ before_script:
     git remote add upstream https://github.com/$TRAVIS_REPO_SLUG.git
     git fetch upstream stable:stable || :
     git fetch upstream master:master || :
-  - kiex selfupdate
-  - test -x ~/.kiex/elixirs/elixir-1.4.4/bin/elixir || kiex install 1.4.4
-  - kiex default 1.4.4
+  # Install kerl; build gmake 4.2.1 and OTP
+  - $TRAVIS_BUILD_DIR/.travis.sh $OTP_TAG_NAME
+  - export PATH="$HOME/bin:$PATH"
+  - source "$HOME/otp/$OTP_TAG_NAME/activate"
+  - kerl active
+  - test -s "$HOME/.kiex/scripts/kiex" && source "$HOME/.kiex/scripts/kiex"
+  - test -x "$HOME/.kiex/elixirs/elixir-1.4.4/bin/elixir" || kiex install 1.4.4
+  - kiex use 1.4.4 --default
+  - mix local.hex --force
+  - export PATH="$HOME/gmake/bin:$PATH"
+  - make --version
+  - $TRAVIS_BUILD_DIR/.travis.sh kiex_cleanup
 
-script: make tests
+script:
+  - make tests
 
 cache:
   directories:
-    - ~/.kiex/elixirs
+    - "$HOME/otp"
+    - "$HOME/.kiex"
+    - "$HOME/gmake"
+    - "$HOME/bin"

--- a/test/system_SUITE.erl
+++ b/test/system_SUITE.erl
@@ -32,7 +32,7 @@
 
 %% The wait constant defines how long a consumer waits before it
 %% unsubscribes
--define(WAIT, 200).
+-define(WAIT, 500).
 
 %% How to long wait for a process to die after an expected failure
 -define(PROCESS_EXIT_TIMEOUT, 5000).


### PR DESCRIPTION
The OTP packages that Travis CI downloads when you specify `language: erlang` don't work with Elixir 1.4.4

I've put together a script and `.travis.yml` that will build the necessary OTP versions and then cache the results. I also have GNU Make 4.2.1 built because I got tired of seeing the warnings from `erlang.mk`