### PR TITLE
Fix channels being killed on connection close

### DIFF
--- a/src/amqp_channel_sup_sup.erl
+++ b/src/amqp_channel_sup_sup.erl
@@ -42,4 +42,4 @@ init([Type, Connection, ConnName]) ->
     {ok, {{simple_one_for_one, 0, 1},
           [{channel_sup,
             {amqp_channel_sup, start_link, [Type, Connection, ConnName]},
-            temporary, brutal_kill, supervisor, [amqp_channel_sup]}]}}.
+            temporary, infinity, supervisor, [amqp_channel_sup]}]}}.

--- a/src/amqp_network_connection.erl
+++ b/src/amqp_network_connection.erl
@@ -86,6 +86,9 @@ handle_message({Ref, {error, Reason}},
                {_,          _} -> {socket_error, Reason}
            end, State}.
 
+closing(_ChannelCloseType, {server_initiated_close, _, _} = Reason, State) ->
+    {ok, State#state{waiting_socket_close = true,
+                     closing_reason = Reason}};
 closing(_ChannelCloseType, Reason, State) ->
     {ok, State#state{closing_reason = Reason}}.
 


### PR DESCRIPTION
When the server initiates an AMQP connection close, it sends a `Connection.Close` frame to the client. When it receives one, the Erlang client `amqp_gen_connection` process does the following steps:

1. It notifies the `amqp_channels_manager` process, asking channels to be terminated.
2. It waits for channels to terminate.

Here, the channels are expected to terminate before the TCP connection is closed. When this happens in this order, Everything Is Fine™.

However, when the TCP connection is closed before channel processes had a chance to terminate, the connection process exits. Because the the `amqp_channel_sup` supervisor, managed by the `amqp_channel_sup_sup` supervisor, has a restart strategy of `brutal_kill`, this supervisor and all its children (including the channel process) are killed.

From the rabbitmq-federation plugin PoV, the link process crashes with the reason `{upstream_channel_down, killed}` or  `{downstream_channel_down, killed}`.