### PR TITLE
Since apps have deps, we should be using ensure_all_started

### DIFF
--- a/src/amqp_client.erl
+++ b/src/amqp_client.erl
@@ -31,11 +31,9 @@ start() ->
     %%
     %%  * https://github.com/rabbitmq/rabbitmq-erlang-client/issues/72
     %%  * https://github.com/rabbitmq/rabbitmq-common/pull/149
-    application:start(syntax_tools),
-    application:start(compiler),
-    application:start(xmerl),
-    application:start(rabbit_common),
-    application:start(amqp_client).
+    application:ensure_all_started(rabbit_common),
+    {ok, _} = application:ensure_all_started(amqp_client),
+    ok.
 
 %%---------------------------------------------------------------------------
 %% application callbacks

--- a/src/amqp_connection.erl
+++ b/src/amqp_connection.erl
@@ -201,8 +201,9 @@ ensure_started() ->
 ensure_started(App) ->
     case is_pid(application_controller:get_master(App)) andalso amqp_sup:is_ready() of
         true  -> ok;
-        false -> case application:start(App) of
+        false -> case application:ensure_all_started(App) of
                      ok                              -> ok;
+                     {ok, _}                         -> ok;
                      {error, {already_started, App}} -> ok;
                      {error, _} = E                  -> throw(E)
                  end


### PR DESCRIPTION
Part of the fix to rabbitmq/rabbitmq-common#224