### PR TITLE
Only log warning when verify is not set

### DIFF
--- a/src/amqp_ssl.erl
+++ b/src/amqp_ssl.erl
@@ -55,14 +55,17 @@ maybe_add_verify_fun(false, Host, Options) ->
     add_verify_fun_to_opts(lists:keyfind(verify, 1, Options), Host, Options).
 
 maybe_add_verify(Options) ->
-    ?LOG_WARN("Connection (~p): Certificate chain verification is not enabled for this TLS connection. "
-              "Please see https://rabbitmq.com/ssl.html for more information.~n", [self()]),
-    Options.
+    case lists:keymember(verify, 1, Options) of
+        true ->
+            % NB: user has explicitly set 'verify'
+            Options;
+        _ ->
+            ?LOG_WARN("Connection (~p): Certificate chain verification is not enabled for this TLS connection. "
+                    "Please see https://rabbitmq.com/ssl.html for more information.~n", [self()]),
+            Options
+    end.
     % TODO FUTURE 3.8.x
     % verify_peer will become the default in RabbitMQ 3.8.0
-    % case lists:keymember(verify, 1, Options) of
-    %     true ->
-    %         Options;
     %     false ->
     %         [{verify, verify_peer} | Options]
     % end.


### PR DESCRIPTION
We only want to log a warning if the user did not set `verify` at all.

153560538, see #97 