### PR TITLE
WIP: Backport SNI support

### DIFF
--- a/src/amqp_connection.erl
+++ b/src/amqp_connection.erl
@@ -171,7 +171,8 @@ start(AmqpParams, ConnName) when ConnName == undefined; is_binary(ConnName) ->
                 AmqpParams
         end,
     AmqpParams2 = set_connection_name(ConnName, AmqpParams1),
-    {ok, _Sup, Connection} = amqp_sup:start_connection_sup(AmqpParams2),
+    AmqpParams3 = amqp_ssl:maybe_enhance_ssl_options(AmqpParams2),
+    {ok, _Sup, Connection} = amqp_sup:start_connection_sup(AmqpParams3),
     amqp_gen_connection:connect(Connection).
 
 set_connection_name(undefined, Params) -> Params;

--- a/src/amqp_ssl.erl
+++ b/src/amqp_ssl.erl
@@ -1,0 +1,116 @@
+-module(amqp_ssl).
+
+-include("amqp_client_internal.hrl").
+
+-include_lib("public_key/include/public_key.hrl").
+
+-export([maybe_enhance_ssl_options/1,
+         add_verify_fun_to_opts/2,
+         verify_fun/3]).
+
+maybe_enhance_ssl_options(Params = #amqp_params_network{ssl_options = none}) ->
+    Params;
+maybe_enhance_ssl_options(Params = #amqp_params_network{host = Host, ssl_options = Opts0}) ->
+    Opts1 = maybe_add_sni(Host, Opts0),
+    Opts2 = maybe_add_verify(Opts1),
+    Params#amqp_params_network{ssl_options = Opts2};
+maybe_enhance_ssl_options(Params) ->
+    Params.
+
+% https://github.com/erlang/otp/blob/master/lib/inets/src/http_client/httpc_handler.erl
+maybe_add_sni(Host, Options) ->
+    maybe_add_sni_0(lists:keyfind(server_name_indication, 1, Options), Host, Options).
+
+maybe_add_sni_0(false, Host, Options) ->
+    % NB: this is the case where the user did not specify
+    % server_name_indication at all. If Host is a DNS host name,
+    % we will specify server_name_indication via code
+    maybe_add_sni_1(inet_parse:domain(Host), Host, Options);
+maybe_add_sni_0({server_name_indication, disable}, _Host, Options) ->
+    % NB: this is the case where the user explicitly disabled
+    % server_name_indication
+    Options;
+maybe_add_sni_0({server_name_indication, SniHost}, _Host, Options) ->
+    % NB: this is the case where the user explicitly specified
+    % an SNI host name. We may need to add verify_fun for OTP 19
+    maybe_add_verify_fun(lists:keymember(verify_fun, 1, Options), SniHost, Options).
+
+maybe_add_sni_1(false, _Host, Options) ->
+    % NB: host is not a DNS host name, so nothing to add
+    Options;
+maybe_add_sni_1(true, _Host, Options) ->
+    % NB: For RabbitMQ 3.7.x, log a warning
+    ?LOG_WARN("Connection (~p): Server name indication is not enabled for this TLS connection. "
+              "Please see https://rabbitmq.com/ssl.html for more information.~n", [self()]),
+    Options.
+    % TODO FUTURE 3.8.x
+    % SNI will become the default in RabbitMQ 3.8.0
+    % Opts1 = [{server_name_indication, Host} | Options],
+    % maybe_add_verify_fun(lists:keymember(verify_fun, 1, Opts1), Host, Opts1).
+
+maybe_add_verify_fun(true, _Host, Options) ->
+    % NB: verify_fun already present, don't add twice
+    Options;
+maybe_add_verify_fun(false, Host, Options) ->
+    add_verify_fun_to_opts(lists:keyfind(verify, 1, Options), Host, Options).
+
+maybe_add_verify(Options) ->
+    ?LOG_WARN("Connection (~p): Certificate chain verification is not enabled for this TLS connection. "
+              "Please see https://rabbitmq.com/ssl.html for more information.~n", [self()]),
+    Options.
+    % TODO FUTURE 3.8.x
+    % verify_peer will become the default in RabbitMQ 3.8.0
+    % case lists:keymember(verify, 1, Options) of
+    %     true ->
+    %         Options;
+    %     false ->
+    %         [{verify, verify_peer} | Options]
+    % end.
+
+add_verify_fun_to_opts(Host, Options) ->
+    add_verify_fun_to_opts(false, Host, Options).
+
+add_verify_fun_to_opts({verify, verify_none}, _Host, Options) ->
+    % NB: this is the case where the user explicitly disabled
+    % certificate chain verification so there's not much sense
+    % in adding verify_fun
+    Options;
+add_verify_fun_to_opts(_, Host, Options) ->
+    % NB: this is the case where the user either did not
+    % set the verify option or set it to verify_peer
+    case erlang:system_info(otp_release) of
+        "19" ->
+            F = fun ?MODULE:verify_fun/3,
+            [{verify_fun, {F, Host}} | Options];
+        _ -> Options
+    end.
+
+-type hostname() :: nonempty_string() | binary().
+
+-spec verify_fun(Cert :: #'OTPCertificate'{},
+                 Event :: {bad_cert, Reason :: atom() | {revoked, atom()}} |
+                          {extension, #'Extension'{}}, InitialUserState :: term()) ->
+                    {valid, UserState :: term()} | {valid_peer, UserState :: hostname()} |
+                    {fail, Reason :: term()} | {unknown, UserState :: term()}.
+verify_fun(_, {bad_cert, _} = Reason, _) ->
+    {fail, Reason};
+verify_fun(_, {extension, _}, UserState) ->
+    {unknown, UserState};
+verify_fun(_, valid, UserState) ->
+    {valid, UserState};
+% NOTE:
+% The user state is the hostname to verify as configured in
+% amqp_ssl:make_verify_fun
+verify_fun(Cert, valid_peer, Hostname) when Hostname =/= disable ->
+    verify_hostname(Cert, Hostname);
+verify_fun(_, valid_peer, UserState) ->
+    {valid, UserState}.
+
+% https://github.com/erlang/otp/blob/master/lib/ssl/src/ssl_certificate.erl
+verify_hostname(Cert, Hostname) ->
+    case public_key:pkix_verify_hostname(Cert, [{dns_id, Hostname}]) of
+        true ->
+            {valid, Hostname};
+        false ->
+            {fail, {bad_cert, hostname_check_failed}}
+    end.

--- a/src/amqp_ssl.erl
+++ b/src/amqp_ssl.erl
@@ -55,14 +55,17 @@ maybe_add_verify_fun(false, Host, Options) ->
     add_verify_fun_to_opts(lists:keyfind(verify, 1, Options), Host, Options).
 
 maybe_add_verify(Options) ->
-    ?LOG_WARN("Connection (~p): Certificate chain verification is not enabled for this TLS connection. "
-              "Please see https://rabbitmq.com/ssl.html for more information.~n", [self()]),
-    Options.
+    case lists:keymember(verify, 1, Options) of
+        true ->
+            % NB: user has explicitly set 'verify'
+            Options;
+        _ ->
+            ?LOG_WARN("Connection (~p): Certificate chain verification is not enabled for this TLS connection. "
+                    "Please see https://rabbitmq.com/ssl.html for more information.~n", [self()]),
+            Options
+    end.
     % TODO FUTURE 3.8.x
     % verify_peer will become the default in RabbitMQ 3.8.0
-    % case lists:keymember(verify, 1, Options) of
-    %     true ->
-    %         Options;
     %     false ->
     %         [{verify, verify_peer} | Options]
     % end.

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -125,35 +125,79 @@ amqp_uri_parsing(_Config) ->
                  amqp_uri:parse("amqp://user:pass@[::1]:100")),
 
     %% TLS options
-    {ok, #amqp_params_network{ssl_options = TLSOpts1}} =
-        amqp_uri:parse("amqps://host/%2f?cacertfile=/path/to/cacertfile.pem"),
-    ?assertEqual(lists:usort([{cacertfile,"/path/to/cacertfile.pem"}]),
+    {ok, #amqp_params_network{host = "host1", ssl_options = TLSOpts1}} =
+        amqp_uri:parse("amqps://host1/%2f?cacertfile=/path/to/cacertfile.pem"),
+    ?assertEqual(lists:usort([{cacertfile,"/path/to/cacertfile.pem"},
+                              {server_name_indication, "host1"},
+                              {verify, verify_peer}]),
                  lists:usort(TLSOpts1)),
 
-    {ok, #amqp_params_network{ssl_options = TLSOpts2}} =
-        amqp_uri:parse("amqps://host/%2f?cacertfile=/path/to/cacertfile.pem"
+    {ok, #amqp_params_network{host = "host2", ssl_options = TLSOpts2}} =
+        amqp_uri:parse("amqps://host2/%2f?cacertfile=/path/to/cacertfile.pem"
                        "&certfile=/path/to/certfile.pem"),
     ?assertEqual(lists:usort([{certfile,  "/path/to/certfile.pem"},
-                              {cacertfile,"/path/to/cacertfile.pem"}]),
+                              {cacertfile,"/path/to/cacertfile.pem"},
+                              {server_name_indication, "host2"},
+                              {verify, verify_peer}]),
                  lists:usort(TLSOpts2)),
 
-    {ok, #amqp_params_network{ssl_options = TLSOpts3}} =
-        amqp_uri:parse("amqps://host/%2f?verify=verify_peer"
+    {ok, #amqp_params_network{host = "host3", ssl_options = TLSOpts3}} =
+        amqp_uri:parse("amqps://host3/%2f?verify=verify_peer"
                        "&fail_if_no_peer_cert=true"),
     ?assertEqual(lists:usort([{fail_if_no_peer_cert, true},
-                              {verify,               verify_peer}
-                             ]), lists:usort(TLSOpts3)),
+                              {verify, verify_peer},
+                              {server_name_indication, "host3"}]),
+                 lists:usort(TLSOpts3)),
 
-    {ok, #amqp_params_network{ssl_options = TLSOpts4}} =
-        amqp_uri:parse("amqps://host/%2f?cacertfile=/path/to/cacertfile.pem"
+    {ok, #amqp_params_network{host = "host4", ssl_options = TLSOpts4}} =
+        amqp_uri:parse("amqps://host4/%2f?cacertfile=/path/to/cacertfile.pem"
+                       "&certfile=/path/to/certfile.pem"
+                       "&password=topsecret"
+                       "&depth=5"),
+    ?assertEqual(lists:usort([{certfile,  "/path/to/certfile.pem"},
+                              {cacertfile,"/path/to/cacertfile.pem"},
+                              {server_name_indication, "host4"},
+                              {verify,    verify_peer},
+                              {password,  "topsecret"},
+                              {depth,     5}]),
+                 lists:usort(TLSOpts4)),
+
+    {ok, #amqp_params_network{host = "host5", ssl_options = TLSOpts5}} =
+        amqp_uri:parse("amqps://host5/%2f?server_name_indication=foobar"),
+    ?assertEqual(lists:usort([{server_name_indication, "foobar"},
+                              {verify, verify_peer}]),
+                 lists:usort(TLSOpts5)),
+
+    {ok, #amqp_params_network{host = "127.0.0.1", ssl_options = TLSOpts6}} =
+        amqp_uri:parse("amqps://127.0.0.1/%2f?server_name_indication=barbaz"),
+    ?assertEqual(lists:usort([{server_name_indication, "barbaz"},
+                              {verify, verify_peer}]),
+                 lists:usort(TLSOpts6)),
+
+    {ok, #amqp_params_network{host = "host7", ssl_options = TLSOpts7}} =
+        amqp_uri:parse("amqps://host7/%2f?server_name_indication=disable"),
+    ?assertEqual(lists:usort([{server_name_indication, disable},
+                              {verify, verify_peer}]),
+                 lists:usort(TLSOpts7)),
+
+    {ok, #amqp_params_network{host = "127.0.0.1", ssl_options = TLSOpts8}} =
+        amqp_uri:parse("amqps://127.0.0.1/%2f?server_name_indication=disable"
+                       "&verify=verify_none"),
+    ?assertEqual(lists:usort([{server_name_indication, disable},
+                              {verify, verify_none}]),
+                 lists:usort(TLSOpts8)),
+
+    {ok, #amqp_params_network{host = "127.0.0.1", ssl_options = TLSOpts9}} =
+        amqp_uri:parse("amqps://127.0.0.1/%2f?cacertfile=/path/to/cacertfile.pem"
                        "&certfile=/path/to/certfile.pem"
                        "&password=topsecret"
                        "&depth=5"),
     ?assertEqual(lists:usort([{certfile,  "/path/to/certfile.pem"},
                               {cacertfile,"/path/to/cacertfile.pem"},
                               {password,  "topsecret"},
+                              {verify,    verify_peer},
                               {depth,     5}]),
-                 lists:usort(TLSOpts4)),
+                 lists:usort(TLSOpts9)),
 
     %% Various failure cases
     ?assertMatch({error, _}, amqp_uri:parse("http://www.rabbitmq.com")),

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -127,57 +127,58 @@ amqp_uri_parsing(_Config) ->
     %% TLS options
     {ok, #amqp_params_network{host = "host1", ssl_options = TLSOpts1}} =
         amqp_uri:parse("amqps://host1/%2f?cacertfile=/path/to/cacertfile.pem"),
-    ?assertEqual(lists:usort([{cacertfile,"/path/to/cacertfile.pem"},
-                              {server_name_indication, "host1"},
-                              {verify, verify_peer}]),
-                 lists:usort(TLSOpts1)),
+    Exp1 = [{cacertfile,"/path/to/cacertfile.pem"}],
+    ?assertEqual(lists:usort(Exp1), lists:usort(TLSOpts1)),
 
     {ok, #amqp_params_network{host = "host2", ssl_options = TLSOpts2}} =
-        amqp_uri:parse("amqps://host2/%2f?cacertfile=/path/to/cacertfile.pem"
+        amqp_uri:parse("amqps://host2/%2F?verify=verify_peer"
+                       "&server_name_indication=host2"
+                       "&cacertfile=/path/to/cacertfile.pem"
                        "&certfile=/path/to/certfile.pem"),
-    ?assertEqual(lists:usort([{certfile,  "/path/to/certfile.pem"},
-                              {cacertfile,"/path/to/cacertfile.pem"},
-                              {server_name_indication, "host2"},
-                              {verify, verify_peer}]),
-                 lists:usort(TLSOpts2)),
+    Opts2 = [{certfile,  "/path/to/certfile.pem"},
+             {cacertfile,"/path/to/cacertfile.pem"},
+             {server_name_indication, "host2"},
+             {verify, verify_peer}],
+    Exp2 = amqp_ssl:add_verify_fun_to_opts("host2", Opts2),
+    ?assertEqual(lists:usort(Exp2), lists:usort(TLSOpts2)),
 
     {ok, #amqp_params_network{host = "host3", ssl_options = TLSOpts3}} =
         amqp_uri:parse("amqps://host3/%2f?verify=verify_peer"
                        "&fail_if_no_peer_cert=true"),
-    ?assertEqual(lists:usort([{fail_if_no_peer_cert, true},
-                              {verify, verify_peer},
-                              {server_name_indication, "host3"}]),
-                 lists:usort(TLSOpts3)),
+    Exp3 = [{fail_if_no_peer_cert, true},
+            {verify, verify_peer}],
+    ?assertEqual(lists:usort(Exp3), lists:usort(TLSOpts3)),
 
     {ok, #amqp_params_network{host = "host4", ssl_options = TLSOpts4}} =
         amqp_uri:parse("amqps://host4/%2f?cacertfile=/path/to/cacertfile.pem"
                        "&certfile=/path/to/certfile.pem"
                        "&password=topsecret"
                        "&depth=5"),
-    ?assertEqual(lists:usort([{certfile,  "/path/to/certfile.pem"},
-                              {cacertfile,"/path/to/cacertfile.pem"},
-                              {server_name_indication, "host4"},
-                              {verify,    verify_peer},
-                              {password,  "topsecret"},
-                              {depth,     5}]),
-                 lists:usort(TLSOpts4)),
+    Exp4 = [{certfile,  "/path/to/certfile.pem"},
+            {cacertfile,"/path/to/cacertfile.pem"},
+            {password,  "topsecret"},
+            {depth,     5}],
+    ?assertEqual(lists:usort(Exp4), lists:usort(TLSOpts4)),
 
     {ok, #amqp_params_network{host = "host5", ssl_options = TLSOpts5}} =
-        amqp_uri:parse("amqps://host5/%2f?server_name_indication=foobar"),
-    ?assertEqual(lists:usort([{server_name_indication, "foobar"},
-                              {verify, verify_peer}]),
-                 lists:usort(TLSOpts5)),
+        amqp_uri:parse("amqps://host5/%2f?server_name_indication=foobar"
+                       "&verify=verify_peer"),
+    Opts5 = [{server_name_indication, "foobar"},
+             {verify, verify_peer}],
+    Exp5 = amqp_ssl:add_verify_fun_to_opts("foobar", Opts5),
+    ?assertEqual(lists:usort(Exp5), lists:usort(TLSOpts5)),
 
     {ok, #amqp_params_network{host = "127.0.0.1", ssl_options = TLSOpts6}} =
-        amqp_uri:parse("amqps://127.0.0.1/%2f?server_name_indication=barbaz"),
-    ?assertEqual(lists:usort([{server_name_indication, "barbaz"},
-                              {verify, verify_peer}]),
-                 lists:usort(TLSOpts6)),
+        amqp_uri:parse("amqps://127.0.0.1/%2f?server_name_indication=barbaz"
+                       "&verify=verify_peer"),
+    Opts6 = [{server_name_indication, "barbaz"},
+             {verify, verify_peer}],
+    Exp6 = amqp_ssl:add_verify_fun_to_opts("barbaz", Opts6),
+    ?assertEqual(lists:usort(Exp6), lists:usort(TLSOpts6)),
 
     {ok, #amqp_params_network{host = "host7", ssl_options = TLSOpts7}} =
         amqp_uri:parse("amqps://host7/%2f?server_name_indication=disable"),
-    ?assertEqual(lists:usort([{server_name_indication, disable},
-                              {verify, verify_peer}]),
+    ?assertEqual(lists:usort([{server_name_indication, disable}]),
                  lists:usort(TLSOpts7)),
 
     {ok, #amqp_params_network{host = "127.0.0.1", ssl_options = TLSOpts8}} =
@@ -195,9 +196,15 @@ amqp_uri_parsing(_Config) ->
     ?assertEqual(lists:usort([{certfile,  "/path/to/certfile.pem"},
                               {cacertfile,"/path/to/cacertfile.pem"},
                               {password,  "topsecret"},
-                              {verify,    verify_peer},
                               {depth,     5}]),
                  lists:usort(TLSOpts9)),
+
+    {ok, #amqp_params_network{host = "host10", ssl_options = TLSOpts10}} =
+        amqp_uri:parse("amqps://host10/%2f?server_name_indication=host10"
+                       "&verify=verify_none"),
+    Exp10 = [{server_name_indication, "host10"},
+             {verify, verify_none}],
+    ?assertEqual(lists:usort(Exp10), lists:usort(TLSOpts10)),
 
     %% Various failure cases
     ?assertMatch({error, _}, amqp_uri:parse("http://www.rabbitmq.com")),


### PR DESCRIPTION
This backports support for Server Name Indication when RabbitMQ is running under Erlang 20.X