### PR TITLE
Use {active,once} instead of async_recv

### DIFF
--- a/src/amqp_connection_type_sup.erl
+++ b/src/amqp_connection_type_sup.erl
@@ -61,12 +61,14 @@ start_infrastructure_fun(Sup, Conn, network) ->
                    {rabbit_writer, start_link,
                     [Sock, 0, ?FRAME_MIN_SIZE, ?PROTOCOL, Conn, ConnName]},
                    transient, ?WORKER_WAIT, worker, [rabbit_writer]}),
-            {ok, _Reader} =
+            {ok, Reader} =
                 supervisor2:start_child(
                   Sup,
                   {main_reader, {amqp_main_reader, start_link,
                                  [Sock, Conn, ChMgr, AState, ConnName]},
                    transient, ?WORKER_WAIT, worker, [amqp_main_reader]}),
+            rabbit_net:controlling_process(Sock, Reader),
+            amqp_main_reader:post_init(Reader),
             {ok, ChMgr, Writer}
     end;
 start_infrastructure_fun(Sup, Conn, direct) ->

--- a/src/amqp_main_reader.erl
+++ b/src/amqp_main_reader.erl
@@ -21,11 +21,12 @@
 
 -behaviour(gen_server).
 
--export([start_link/5]).
+-export([start_link/5, post_init/1]).
 -export([init/1, terminate/2, code_change/3, handle_call/3, handle_cast/2,
          handle_info/2]).
 
 -record(state, {sock,
+                timer,
                 connection,
                 channels_manager,
                 astate,
@@ -40,6 +41,9 @@ start_link(Sock, Connection, ChMgr, AState, ConnName) ->
     gen_server:start_link(
       ?MODULE, [Sock, Connection, ConnName, ChMgr, AState], []).
 
+post_init(Reader) ->
+    gen_server:call(Reader, post_init).
+
 %%---------------------------------------------------------------------------
 %% gen_server callbacks
 %%---------------------------------------------------------------------------
@@ -51,11 +55,7 @@ init([Sock, Connection, ConnName, ChMgr, AState]) ->
                    channels_manager = ChMgr,
                    astate           = AState,
                    message          = none},
-    case rabbit_net:async_recv(Sock, 0, amqp_util:call_timeout()) of
-        {ok, _}         -> {ok, State};
-        {error, Reason} -> {stop, Reason, _} = handle_error(Reason, State),
-                           {stop, Reason}
-    end.
+    {ok, State}.
 
 terminate(_Reason, _State) ->
     ok.
@@ -63,22 +63,33 @@ terminate(_Reason, _State) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
+%% We need to use a call because we are not controlling the socket yet.
+handle_call(post_init, _From, State = #state{sock = Sock}) ->
+    case rabbit_net:setopts(Sock, [{active, once}]) of
+        ok              -> {reply, ok, set_timeout(State)};
+        {error, Reason} -> handle_error(Reason, State)
+    end;
 handle_call(Call, From, State) ->
     {stop, {unexpected_call, Call, From}, State}.
 
 handle_cast(Cast, State) ->
     {stop, {unexpected_cast, Cast}, State}.
 
-handle_info({inet_async, Sock, _, {ok, Data}},
-            State = #state {sock = Sock}) ->
+handle_info({Tag, Sock, Data}, State = #state{sock = Sock})
+            when Tag =:= tcp; Tag =:= ssl ->
     %% Latency hiding: Request next packet first, then process data
-    case rabbit_net:async_recv(Sock, 0, amqp_util:call_timeout()) of
-         {ok, _}         -> handle_data(Data, State);
+    case rabbit_net:setopts(Sock, [{active, once}]) of
+         ok              -> handle_data(Data, set_timeout(State));
          {error, Reason} -> handle_error(Reason, State)
     end;
-handle_info({inet_async, Sock, _, {error, Reason}},
-            State = #state{sock = Sock}) ->
-    handle_error(Reason, State).
+handle_info({Tag, Sock}, State = #state{sock = Sock})
+            when Tag =:= tcp_closed; Tag =:= ssl_closed ->
+    handle_error(closed, State);
+handle_info({Tag, Sock, Reason}, State = #state{sock = Sock})
+            when Tag =:= tcp_error; Tag =:= ssl_error ->
+    handle_error(Reason, State);
+handle_info({timeout, TimerRef, idle_timeout}, State = #state{timer = TimerRef}) ->
+    handle_error(timeout, State).
 
 handle_data(<<Type:8, Channel:16, Length:32, Payload:Length/binary, ?FRAME_END,
               More/binary>>,
@@ -120,6 +131,21 @@ handle_data(<<>>, State) ->
 %%---------------------------------------------------------------------------
 %% Internal plumbing
 %%---------------------------------------------------------------------------
+
+set_timeout(State0) ->
+	State = cancel_timeout(State0),
+	TimerRef = case amqp_util:call_timeout() of
+		infinity -> undefined;
+		Timeout -> erlang:start_timer(Timeout, self(), idle_timeout)
+	end,
+	State#state{timer=TimerRef}.
+
+cancel_timeout(State=#state{timer=TimerRef}) ->
+	ok = case TimerRef of
+		undefined -> ok;
+		_ -> erlang:cancel_timer(TimerRef, [{async, true}, {info, false}])
+	end,
+	State#state{timer=undefined}.
 
 process_frame(Type, ChNumber, Payload,
               State = #state{connection       = Connection,

--- a/test/system_SUITE.erl
+++ b/test/system_SUITE.erl
@@ -1266,9 +1266,32 @@ connection_failure(Config) ->
             end;
         [{type, network}, {amqp_params, _}] ->
             [{sock, Sock}] = amqp_connection:info(Connection, [sock]),
-            ok = gen_tcp:close(Sock)
+            close_remote_socket(Config, Sock)
     end,
     wait_for_death(Connection).
+
+%% We obtain the socket for the remote end of the connection by
+%% looking through open ports and comparing sockname/peername values.
+%% This is necessary because we cannot close our own socket to test
+%% connection failures; a close is expected.
+%%
+%% We need to convert the IPv4 to IPv6 because the server side
+%% will use the IPv6 format due to it being enabled for other tests.
+close_remote_socket(Config, Socket) when is_port(Socket) ->
+    {ok, {IPv4, Port}} = inet:sockname(Socket),
+    IPv6 = inet:ipv4_mapped_ipv6_address(IPv4),
+    rabbit_ct_broker_helpers:rpc(Config, 0,
+        ?MODULE, close_remote_socket, [{ok, {IPv6, Port}}]).
+
+close_remote_socket(SockName) ->
+    AllPorts = [{P, erlang:port_info(P)} || P <- erlang:ports()],
+    [RemoteSocket] = [
+        P
+    || {P, I} <- AllPorts,
+        I =/= undefined,
+        proplists:get_value(name, I) =:= "tcp_inet",
+        inet:peername(P) =:= SockName],
+    ok = gen_tcp:close(RemoteSocket).
 
 %% -------------------------------------------------------------------
 


### PR DESCRIPTION
A test had to be changed because closing the socket locally
does not trigger the condition we expect. It happened to work
before because async_recv is using a low level interface but
it wasn't really testing the right thing.

This is a followup to https://github.com/rabbitmq/rabbitmq-stomp/pull/128