### PR TITLE
Fix Dialyzer warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,10 +11,10 @@
 /git-revisions.txt
 /logs/
 /PACKAGES/
+*.plt
 /plugins/
 /rebar.config
 /rebar.lock
 /test/ct.cover.spec
 /xrefr
-
 /amqp_client.d

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@ DEP_PLUGINS = rabbit_common/mk/rabbitmq-build.mk \
 	      rabbit_common/mk/rabbitmq-test.mk \
 	      rabbit_common/mk/rabbitmq-tools.mk
 
+PLT_APPS = ssl public_key
+
 # FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
 # reviewed and merged.
 

--- a/src/amqp_uri.erl
+++ b/src/amqp_uri.erl
@@ -277,5 +277,6 @@ run_state_monad(FunList, State) ->
 
 return(V) -> V.
 
+-spec fail(_) -> no_return().
 fail(Reason) -> throw(Reason).
 %% --=: end :=--

--- a/src/rabbit_routing_util.erl
+++ b/src/rabbit_routing_util.erl
@@ -212,8 +212,6 @@ queue_declare_method(#'queue.declare'{} = Method, Type, Params) ->
             Method2#'queue.declare'{queue = SQNG()};
         {exchange, SQNG} when is_function(SQNG) ->
             Method2#'queue.declare'{queue = SQNG()};
-        {'reply-queue', SQNG} when is_function(SQNG) ->
-            Method2#'queue.declare'{queue = SQNG()};
         _ ->
             Method2
     end.

--- a/src/uri_parser.erl
+++ b/src/uri_parser.erl
@@ -39,7 +39,9 @@
 %% are: 'scheme', 'userinfo', 'host', 'port', 'path', 'query',
 %% 'fragment'.
 
--spec parse(AbsURI :: string() | binary(), Defaults :: list()) -> string().
+-spec parse(AbsURI, Defaults :: list())
+    -> [{atom(), string()}] | {error, no_scheme | {malformed_uri, AbsURI, any()}}
+    when AbsURI :: string() | binary().
 parse(AbsURI, Defaults) ->
     AbsUriString = rabbit_data_coercion:to_list(AbsURI),
     case parse_scheme(AbsUriString) of


### PR DESCRIPTION
There are 4 warnings remaining that *should* be fixed whenever Erlang.mk gets updated.