### PR TITLE
Spelling

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -1340,7 +1340,7 @@ pkg_erlang_cep_commit = master
 
 PACKAGES += erlang_js
 pkg_erlang_js_name = erlang_js
-pkg_erlang_js_description = A linked-in driver for Erlang to Mozilla's Spidermonkey Javascript runtime.
+pkg_erlang_js_description = A linked-in driver for Erlang to Mozilla's Spidermonkey JavaScript runtime.
 pkg_erlang_js_homepage = https://github.com/basho/erlang_js
 pkg_erlang_js_fetch = git
 pkg_erlang_js_repo = https://github.com/basho/erlang_js

--- a/erlang.mk
+++ b/erlang.mk
@@ -4132,7 +4132,7 @@ pkg_yaws_commit = master
 
 PACKAGES += zab_engine
 pkg_zab_engine_name = zab_engine
-pkg_zab_engine_description = zab propotocol implement by erlang
+pkg_zab_engine_description = zab protocol implement by erlang
 pkg_zab_engine_homepage = https://github.com/xinmingyao/zab_engine
 pkg_zab_engine_fetch = git
 pkg_zab_engine_repo = https://github.com/xinmingyao/zab_engine

--- a/erlang.mk
+++ b/erlang.mk
@@ -596,7 +596,7 @@ pkg_check_node_commit = master
 
 PACKAGES += chronos
 pkg_chronos_name = chronos
-pkg_chronos_description = Timer module for Erlang that makes it easy to abstact time out of the tests.
+pkg_chronos_description = Timer module for Erlang that makes it easy to abstract time out of the tests.
 pkg_chronos_homepage = https://github.com/lehoff/chronos
 pkg_chronos_fetch = git
 pkg_chronos_repo = https://github.com/lehoff/chronos

--- a/rabbitmq-components.mk
+++ b/rabbitmq-components.mk
@@ -226,7 +226,7 @@ export base_rmq_ref
 # If cloning from this computed location fails, we fallback to RabbitMQ
 # upstream which is GitHub.
 
-# Maccro to transform eg. "rabbit_common" to "rabbitmq-common".
+# Macro to transform eg. "rabbit_common" to "rabbitmq-common".
 rmq_cmp_repo_name = $(word 2,$(dep_$(1)))
 
 # Upstream URL for the current project.

--- a/src/amqp_connection.erl
+++ b/src/amqp_connection.erl
@@ -117,7 +117,7 @@
 %%     defaults to 0</li>
 %% <li>frame_max :: non_neg_integer() - The frame_max handshake parameter,
 %%     defaults to 0 (network only)</li>
-%% <li>heartbeat :: non_neg_integer() - The hearbeat interval in seconds,
+%% <li>heartbeat :: non_neg_integer() - The heartbeat interval in seconds,
 %%     defaults to 0 (turned off) (network only)</li>
 %% <li>connection_timeout :: non_neg_integer() | 'infinity'
 %%     - The connection timeout in milliseconds,

--- a/src/amqp_rpc_client.erl
+++ b/src/amqp_rpc_client.erl
@@ -68,7 +68,7 @@ start_link(Connection, Queue) ->
 %% @spec (RpcClient) -> ok
 %% where
 %%      RpcClient = pid()
-%% @doc Stops an exisiting RPC client.
+%% @doc Stops an existing RPC client.
 stop(Pid) ->
     gen_server:call(Pid, stop, amqp_util:call_timeout()).
 

--- a/src/amqp_rpc_server.erl
+++ b/src/amqp_rpc_server.erl
@@ -68,7 +68,7 @@ start_link(Connection, Queue, Fun) ->
 %% @spec (RpcServer) -> ok
 %% where
 %%      RpcServer = pid()
-%% @doc Stops an exisiting RPC server.
+%% @doc Stops an existing RPC server.
 stop(Pid) ->
     gen_server:call(Pid, stop, amqp_util:call_timeout()).
 

--- a/src/amqp_selective_consumer.erl
+++ b/src/amqp_selective_consumer.erl
@@ -1,4 +1,4 @@
-%% The contents of this file are subject to the Mozilla Public Licensbe
+%% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License at
 %% http://www.mozilla.org/MPL/

--- a/test/system_SUITE.erl
+++ b/test/system_SUITE.erl
@@ -687,7 +687,7 @@ queue_unbind(Config) ->
 
 %% -------------------------------------------------------------------
 
-%% This is designed to exercize the internal queuing mechanism
+%% This is designed to exercise the internal queuing mechanism
 %% to ensure that sync methods are properly serialized
 sync_method_serialization(Config) ->
     abstract_method_serialization_test(
@@ -703,7 +703,7 @@ sync_method_serialization(Config) ->
         end,
         fun (_, _, _, _, _) -> ok end).
 
-%% This is designed to exercize the internal queuing mechanism
+%% This is designed to exercise the internal queuing mechanism
 %% to ensure that sending async methods and then a sync method is serialized
 %% properly
 async_sync_method_serialization(Config) ->
@@ -735,7 +735,7 @@ async_sync_method_serialization(Config) ->
                                                        passive = true})
         end).
 
-%% This is designed to exercize the internal queuing mechanism
+%% This is designed to exercise the internal queuing mechanism
 %% to ensure that sending sync methods and then an async method is serialized
 %% properly
 sync_async_method_serialization(Config) ->

--- a/test/system_SUITE.erl
+++ b/test/system_SUITE.erl
@@ -899,7 +899,7 @@ rpc_client_consume_loop(Channel) ->
 %% -------------------------------------------------------------------
 
 %% Test for the network client
-%% Sends a bunch of messages and immediatly closes the connection without
+%% Sends a bunch of messages and immediately closes the connection without
 %% closing the channel. Then gets the messages back from the queue and expects
 %% all of them to have been sent.
 pub_and_close(Config) ->

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -94,7 +94,7 @@ amqp_uri_parsing(_Config) ->
     ?assertMatch({ok, #amqp_params_network{host = "::1"}},
                  amqp_uri:parse("amqp://[::1]")),
 
-    %% Varous other cases
+    %% Various other cases
     ?assertMatch({ok, #amqp_params_network{host = "host", port = 100}},
                  amqp_uri:parse("amqp://host:100")),
     ?assertMatch({ok, #amqp_params_network{host = "::1", port = 100}},


### PR DESCRIPTION
## Proposed Changes

Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`

Note: I've filed some issues and made some PRs on some of the pkg_ items changed below, so they may technically not be incorrect today, but I believe that the changes should be made both here and upstream.

There are a number of benefits of using correct spelling, one is that it makes it easier to read, another is that it makes it easier to search/cross reference, another is that it reduces ambiguity/confusion.

I'm not claiming to be an erlang expert/user (we're investigating using RabbitMQ for a system, and I like to test the waters of projects to get a sense of how healthy they are with small changes). I haven't yet set up an erlang environment. So I haven't run the tests yet (I can, and understand that the contribution guide encourages me to do so).