### PR TITLE
Move rabbit_queue_collector to rabbit_common repo

### DIFF
--- a/src/amqp_direct_connection.erl
+++ b/src/amqp_direct_connection.erl
@@ -88,7 +88,7 @@ closing(_ChannelCloseType, Reason, State) ->
 
 channels_terminated(State = #state{closing_reason = Reason,
                                    collector = Collector}) ->
-    rabbit_queue_collector_common:delete_all(Collector),
+    rabbit_queue_collector:delete_all(Collector),
     {stop, {shutdown, Reason}, State}.
 
 terminate(_Reason, #state{node = Node} = State) ->


### PR DESCRIPTION
Collector is used by a connection supervisor, which may be on
the client side for direct connections.

Addresses #91.

Depends on changes in rabbitmq-server and rabbitmq-common:
https://github.com/rabbitmq/rabbitmq-common/pull/325
https://github.com/rabbitmq/rabbitmq-server/pull/1989