### PR TITLE
Avoid pattern matching with timers when handling timeouts

### DIFF
--- a/src/amqp_main_reader.erl
+++ b/src/amqp_main_reader.erl
@@ -88,7 +88,7 @@ handle_info({Tag, Sock}, State = #state{sock = Sock})
 handle_info({Tag, Sock, Reason}, State = #state{sock = Sock})
             when Tag =:= tcp_error; Tag =:= ssl_error ->
     handle_error(Reason, State);
-handle_info({timeout, TimerRef, idle_timeout}, State = #state{timer = TimerRef}) ->
+handle_info({timeout, _TimerRef, idle_timeout}, State) ->
     handle_error(timeout, State).
 
 handle_data(<<Type:8, Channel:16, Length:32, Payload:Length/binary, ?FRAME_END,


### PR DESCRIPTION
Hi, this PR aim to fix a bug we are facing in our production apps.
We're experiencing a lot of timeouts on our infrastructure but the connections are not restarted automatically. We found that the genserver handling timeouts is failing to shutdown properly because is trying to match the timer that generated timeout with one inside his state, but, for reasons we can't understand (problably a race condition), this two are different.

You can see this happening inside this log:
```
GenServer #PID<0.11758.44> terminating
** (FunctionClauseError) no function clause matching in :amqp_main_reader.handle_info/2
    (amqp_client) /drone/src/deps/amqp_client/src/amqp_main_reader.erl:78: :amqp_main_reader.handle_info({:timeout, #Reference<0.3864832014.1612447748.24168>, :idle_timeout}, {:state, #Port<0.213>, #Reference<0.3864832014.1612447748.24192>, #PID<0.11741.44>, #PID<0.11738.44>, {:method, :rabbit_framing_amqp_0_9_1}, {:expecting_header, ""}})
    (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: {:timeout, #Reference<0.3864832014.1612447748.24168>, :idle_timeout}
```
At this point, the root supervisor doesn't crash or shuts down and we're not able to detect that connection was terminated. 

We propose to skip pattern matching and handle timeouts anyway 
