### PR TITLE
pass amqp parameters for direct channel to avoid sync call to the connection process

### DIFF
--- a/src/amqp_channel_sup.erl
+++ b/src/amqp_channel_sup.erl
@@ -47,12 +47,12 @@ start_link(Type, Connection, ConnName, InfraArgs, ChNumber,
 %% Internal plumbing
 %%---------------------------------------------------------------------------
 
-start_writer(_Sup, direct, [ConnPid, Node, User, VHost, Collector],
+start_writer(_Sup, direct, [ConnPid, Node, User, VHost, Collector, AmqpParams],
              ConnName, ChNumber, ChPid) ->
     {ok, RabbitCh} =
         rpc:call(Node, rabbit_direct, start_channel,
                  [ChNumber, ChPid, ConnPid, ConnName, ?PROTOCOL, User,
-                  VHost, ?CLIENT_CAPABILITIES, Collector]),
+                  VHost, ?CLIENT_CAPABILITIES, Collector, AmqpParams]),
     RabbitCh;
 start_writer(Sup, network, [Sock, FrameMax], ConnName, ChNumber, ChPid) ->
     {ok, Writer} = supervisor2:start_child(

--- a/src/amqp_direct_connection.erl
+++ b/src/amqp_direct_connection.erl
@@ -62,8 +62,9 @@ init() ->
 open_channel_args(#state{node = Node,
                          user = User,
                          vhost = VHost,
-                         collector = Collector}) ->
-    [self(), Node, User, VHost, Collector].
+                         collector = Collector,
+                         params = Params}) ->
+    [self(), Node, User, VHost, Collector, Params].
 
 do(_Method, _State) ->
     ok.


### PR DESCRIPTION
performance optimisation

Part of rabbitmq/rabbitmq-server/pull/2169