### PR TITLE
Pass client/connection parameters to direct channel at init time to avoid a sync call to the connection process

### DIFF
--- a/src/amqp_channel_sup.erl
+++ b/src/amqp_channel_sup.erl
@@ -47,12 +47,12 @@ start_link(Type, Connection, ConnName, InfraArgs, ChNumber,
 %% Internal plumbing
 %%---------------------------------------------------------------------------
 
-start_writer(_Sup, direct, [ConnPid, Node, User, VHost, Collector],
+start_writer(_Sup, direct, [ConnPid, Node, User, VHost, Collector, AmqpParams],
              ConnName, ChNumber, ChPid) ->
     {ok, RabbitCh} =
         rpc:call(Node, rabbit_direct, start_channel,
                  [ChNumber, ChPid, ConnPid, ConnName, ?PROTOCOL, User,
-                  VHost, ?CLIENT_CAPABILITIES, Collector]),
+                  VHost, ?CLIENT_CAPABILITIES, Collector, AmqpParams]),
     RabbitCh;
 start_writer(Sup, network, [Sock, FrameMax], ConnName, ChNumber, ChPid) ->
     {ok, Writer} = supervisor2:start_child(

--- a/src/amqp_direct_connection.erl
+++ b/src/amqp_direct_connection.erl
@@ -62,8 +62,9 @@ init() ->
 open_channel_args(#state{node = Node,
                          user = User,
                          vhost = VHost,
-                         collector = Collector}) ->
-    [self(), Node, User, VHost, Collector].
+                         collector = Collector,
+                         params = Params}) ->
+    [self(), Node, User, VHost, Collector, Params].
 
 do(_Method, _State) ->
     ok.

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -367,23 +367,26 @@ rabbit_channel_build_topic_variable_map(_Config) ->
                 {variable_map, #{<<"client_id">> => <<"client99">>}}]}
     },
     %% simple case
-    #{<<"client_id">> := <<"client99">>,
-      <<"username">>  := <<"guest">>,
-      <<"vhost">>     := <<"default">>} = rabbit_channel:build_topic_variable_map(
+    ?assertMatch(
+        #{<<"client_id">> := <<"client99">>,
+          <<"username">>  := <<"guest">>,
+          <<"vhost">>     := <<"default">>}, rabbit_channel:build_topic_variable_map(
         [{amqp_params, AmqpParams}], <<"default">>, <<"guest">>
-    ),
+    )),
     %% nothing to add
     AmqpParams1 = #amqp_params_direct{adapter_info = #amqp_adapter_info{}},
-    #{<<"username">>  := <<"guest">>,
-      <<"vhost">>     := <<"default">>} = rabbit_channel:build_topic_variable_map(
+    ?assertMatch(
+        #{<<"username">>  := <<"guest">>,
+          <<"vhost">>     := <<"default">>}, rabbit_channel:build_topic_variable_map(
         [{amqp_params, AmqpParams1}], <<"default">>, <<"guest">>
-    ),
+    )),
     %% nothing to add with amqp_params_network
     AmqpParams2 = #amqp_params_network{},
-    #{<<"username">>  := <<"guest">>,
-      <<"vhost">>     := <<"default">>} = rabbit_channel:build_topic_variable_map(
+    ?assertMatch(
+        #{<<"username">>  := <<"guest">>,
+         <<"vhost">>     := <<"default">>}, rabbit_channel:build_topic_variable_map(
         [{amqp_params, AmqpParams2}], <<"default">>, <<"guest">>
-    ),
+    )),
     %% trying to override channel variables, but those
     %% take precedence
     AmqpParams3 = #amqp_params_direct{
@@ -392,9 +395,9 @@ rabbit_channel_build_topic_variable_map(_Config) ->
                 {variable_map, #{<<"client_id">> => <<"client99">>,
                                  <<"username">>  => <<"admin">>}}]}
     },
-    #{<<"client_id">> := <<"client99">>,
-      <<"username">>  := <<"guest">>,
-      <<"vhost">>     := <<"default">>} = rabbit_channel:build_topic_variable_map(
+    ?assertMatch(#{<<"client_id">> := <<"client99">>,
+                   <<"username">>  := <<"guest">>,
+                   <<"vhost">>     := <<"default">>}, rabbit_channel:build_topic_variable_map(
         [{amqp_params, AmqpParams3}], <<"default">>, <<"guest">>
-    ),
+    )),
     ok.


### PR DESCRIPTION
This supersedes #127, part of https://github.com/rabbitmq/rabbitmq-server/pull/2172.