### PR TITLE
Be more defensive with TLS socket operations when opening connections

### DIFF
--- a/src/amqp_connection_type_sup.erl
+++ b/src/amqp_connection_type_sup.erl
@@ -60,9 +60,13 @@ start_infrastructure_fun(Sup, Conn, network) ->
                   {main_reader, {amqp_main_reader, start_link,
                                  [Sock, Conn, ChMgr, AState, ConnName]},
                    transient, ?WORKER_WAIT, worker, [amqp_main_reader]}),
-            rabbit_net:controlling_process(Sock, Reader),
-            amqp_main_reader:post_init(Reader),
-            {ok, ChMgr, Writer}
+            case rabbit_net:controlling_process(Sock, Reader) of
+              ok ->
+                ok = amqp_main_reader:post_init(Reader),
+                {ok, ChMgr, Writer};
+              {error, Reason} ->
+                {error, Reason}
+            end
     end;
 start_infrastructure_fun(Sup, Conn, direct) ->
     fun (ConnName) ->

--- a/src/amqp_connection_type_sup.erl
+++ b/src/amqp_connection_type_sup.erl
@@ -62,8 +62,12 @@ start_infrastructure_fun(Sup, Conn, network) ->
                    transient, ?WORKER_WAIT, worker, [amqp_main_reader]}),
             case rabbit_net:controlling_process(Sock, Reader) of
               ok ->
-                ok = amqp_main_reader:post_init(Reader),
-                {ok, ChMgr, Writer};
+                case amqp_main_reader:post_init(Reader) of
+                  ok ->
+                    {ok, ChMgr, Writer};
+                  {error, Reason} ->
+                    {error, Reason}
+                end;
               {error, Reason} ->
                 {error, Reason}
             end

--- a/src/amqp_main_reader.erl
+++ b/src/amqp_main_reader.erl
@@ -33,7 +33,12 @@ start_link(Sock, Connection, ChMgr, AState, ConnName) ->
       ?MODULE, [Sock, Connection, ConnName, ChMgr, AState], []).
 
 post_init(Reader) ->
-    gen_server:call(Reader, post_init, ?CALL_TIMEOUT).
+    try
+      gen_server:call(Reader, post_init, ?CALL_TIMEOUT)
+    catch
+      exit:{timeout, Timeout} ->
+        {error, {timeout, Timeout}}
+    end.
 
 %%---------------------------------------------------------------------------
 %% gen_server callbacks

--- a/src/amqp_main_reader.erl
+++ b/src/amqp_main_reader.erl
@@ -33,7 +33,7 @@ start_link(Sock, Connection, ChMgr, AState, ConnName) ->
       ?MODULE, [Sock, Connection, ConnName, ChMgr, AState], []).
 
 post_init(Reader) ->
-    gen_server:call(Reader, post_init).
+    gen_server:call(Reader, post_init, ?CALL_TIMEOUT).
 
 %%---------------------------------------------------------------------------
 %% gen_server callbacks


### PR DESCRIPTION
Specifically, handle and return the error resulting from `ssl:controlling_process/2` when opening a connection

Also increase the timeout around `ssl:setopts/2` when opening a connection to the global client timeout

Should partly address https://github.com/rabbitmq/rabbitmq-trust-store/issues/80