### PR TITLE
Document the Timeout parameter to wait_for_confirms

### DIFF
--- a/include/amqp_client_internal.hrl
+++ b/include/amqp_client_internal.hrl
@@ -26,7 +26,3 @@
      {<<"consumer_cancel_notify">>,       bool, true},
      {<<"connection.blocked">>,           bool, true},
      {<<"authentication_failure_close">>, bool, true}]).
-
--define(CALL_TIMEOUT, rabbit_misc:get_env(amqp_client, gen_server_call_timeout,
-                                          60000)).
-

--- a/include/amqp_client_internal.hrl
+++ b/include/amqp_client_internal.hrl
@@ -26,3 +26,5 @@
      {<<"consumer_cancel_notify">>,       bool, true},
      {<<"connection.blocked">>,           bool, true},
      {<<"authentication_failure_close">>, bool, true}]).
+
+-define(WAIT_FOR_CONFIRMS_TIMEOUT, {60000, millisecond}).

--- a/src/amqp_channel.erl
+++ b/src/amqp_channel.erl
@@ -215,6 +215,8 @@ next_publish_seqno(Channel) ->
 %% @doc Wait until all messages published since the last call have
 %% been either ack'd or nack'd by the broker.  Note, when called on a
 %% non-Confirm channel, waitForConfirms returns an error.
+%% @param Channel: the channel on which to wait.
+%% @end
 wait_for_confirms(Channel) ->
     wait_for_confirms(Channel, amqp_util:call_timeout()).
 
@@ -226,6 +228,9 @@ wait_for_confirms(Channel) ->
 %% been either ack'd or nack'd by the broker or the timeout expires.
 %% Note, when called on a non-Confirm channel, waitForConfirms throws
 %% an exception.
+%% @param Channel: the channel on which to wait.
+%% @param Timeout: the wait timeout in seconds.
+%% @end
 wait_for_confirms(Channel, Timeout) ->
     case gen_server:call(Channel, {wait_for_confirms, Timeout}, amqp_util:call_timeout()) of
         {error, Reason} -> throw(Reason);
@@ -238,6 +243,8 @@ wait_for_confirms(Channel, Timeout) ->
 %% @doc Behaves the same as wait_for_confirms/1, but if a nack is
 %% received, the calling process is immediately sent an
 %% exit(nack_received).
+%% @param Channel: the channel on which to wait.
+%% @end
 wait_for_confirms_or_die(Channel) ->
     wait_for_confirms_or_die(Channel, amqp_util:call_timeout()).
 
@@ -249,6 +256,9 @@ wait_for_confirms_or_die(Channel) ->
 %% received, the calling process is immediately sent an
 %% exit(nack_received). If the timeout expires, the calling process is
 %% sent an exit(timeout).
+%% @param Channel: the channel on which to wait.
+%% @param Timeout: the wait timeout in seconds.
+%% @end
 wait_for_confirms_or_die(Channel, Timeout) ->
     case wait_for_confirms(Channel, Timeout) of
         timeout -> close(Channel, 200, <<"Confirm Timeout">>),

--- a/src/amqp_util.erl
+++ b/src/amqp_util.erl
@@ -9,7 +9,7 @@ call_timeout() ->
         undefined ->
             Timeout = rabbit_misc:get_env(amqp_client,
                                           gen_server_call_timeout,
-                                          ?CALL_TIMEOUT),
+                                          60000),
             put(gen_server_call_timeout, Timeout),
             Timeout;
         Timeout ->


### PR DESCRIPTION
This parameter is in seconds. Also remove superfluous `CALL_TIMEOUT` macro.

cc @dumbbell

Also see rabbitmq/rabbitmq-server#2490